### PR TITLE
Update Gale link

### DIFF
--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -21,7 +21,7 @@ Mod managers handle all the technical setup for you. They automatically install 
   <Card title="Gale" icon="rocket">
     <p>Modern, lightweight mod manager with clean interface.</p>
     <LinkButton
-      href="https://kesomannen.com/gale"
+      href="https://github.com/Kesomannen/gale"
       target={'_blank'}
       rel={'external'}
     >


### PR DESCRIPTION
The current Gale link points to a 404 page. Updating it with a proper GitHub link.